### PR TITLE
Make static colors extensions

### DIFF
--- a/Sources/Graphics/color/Colors.swift
+++ b/Sources/Graphics/color/Colors.swift
@@ -1,12 +1,12 @@
-public struct Colors {
-    public static let red = Color(red: 255, green: 0, blue: 0)
-    public static let green = Color(red: 0, green: 255, blue: 0)
-    public static let blue = Color(red: 0, green: 0, blue: 255)
-    public static let white = Color(red: 255, green: 255, blue: 255)
-    public static let black = Color(red: 0, green: 0, blue: 0)
-    public static let gray = Color(red: 128, green: 128, blue: 128)
-    public static let yellow = Color(red: 255, green: 255, blue: 0)
-    public static let magenta = Color(red: 255, green: 0, blue: 255)
-    public static let cyan = Color(red: 0, green: 255, blue: 255)
-    public static let transparent = Color(red: 0, green: 0, blue: 0, alpha: 0)
+public extension Color {
+    static let red = Color(red: 255, green: 0, blue: 0)
+    static let green = Color(red: 0, green: 255, blue: 0)
+    static let blue = Color(red: 0, green: 0, blue: 255)
+    static let white = Color(red: 255, green: 255, blue: 255)
+    static let black = Color(red: 0, green: 0, blue: 0)
+    static let gray = Color(red: 128, green: 128, blue: 128)
+    static let yellow = Color(red: 255, green: 255, blue: 0)
+    static let magenta = Color(red: 255, green: 0, blue: 255)
+    static let cyan = Color(red: 0, green: 255, blue: 255)
+    static let transparent = Color(red: 0, green: 0, blue: 0, alpha: 0)
 }

--- a/Sources/Graphics/image/Image.swift
+++ b/Sources/Graphics/image/Image.swift
@@ -65,7 +65,7 @@ public class Image {
                 pixel = readColorFrom(pixel: colorPtr)
             }
 
-            return pixel ?? Colors.transparent
+            return pixel ?? .transparent
         }
         set(newColor) {
             dirty = true

--- a/Sources/Graphics/shape/ShapeDefaults.swift
+++ b/Sources/Graphics/shape/ShapeDefaults.swift
@@ -1,4 +1,4 @@
 public struct ShapeDefaults {
-    public static let color = Colors.white
+    public static let color: Color = .white
     public static let isFilled = true
 }

--- a/Sources/Graphics/shape/Text.swift
+++ b/Sources/Graphics/shape/Text.swift
@@ -10,7 +10,7 @@ public struct Text {
         _ value: String,
         withSize fontSize: Double = 12,
         at position: Vec2<Double> = Vec2(x: 0, y: 12),
-        color: Color = Colors.white
+        color: Color = .white
     ) {
         self.value = value
         self.fontSize = fontSize


### PR DESCRIPTION
A minor change to take better usage of auto type inference. I think this is more intuitive.
So that we can use
``` swift
let text = Text("Hello, world!", withSize: 42, at: Vec2(x: 42, y: 42), colors: .black)
```
instead of
``` swift
let text = Text("Hello, world!", withSize: 42, at: Vec2(x: 42, y: 42), colors: Colors.black)
```

Slightly improved coding experiences. 🙂

I've tested on Swift 5.2 and got no error. Should work on any 5.2+.