### PR TITLE
Add polygon primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ ctx.draw(line: LineSegment(fromX: 20, y: 20, toX: 50, y: 30))
 ctx.draw(rect: Rectangle(fromX: 80, y: 90, width: 10, height: 40, color: Colors.yellow))
 ctx.draw(text: Text("Test", at: Vec2(x: 0, y: 15)))
 ctx.draw(ellipse: Ellipse(centerX: 150, y: 80, radius: 40))
+ctx.draw(polygon: Polygon(points: [
+    Vec2(x: 210.0, y: 150.0),
+    Vec2(x: 100.0, y: 200.0),
+    Vec2(x: 170.0, y: 250.0)
+], isFilled: false))
 
 // Encode the image to a byte buffer
 let image = try ctx.makeImage()

--- a/Snippets/DrawShapes.swift
+++ b/Snippets/DrawShapes.swift
@@ -12,10 +12,25 @@ func generatePngImage() throws -> Data {
     ctx.draw(text: Text("Test", at: Vec2(x: 0, y: 15)))
     ctx.draw(ellipse: Ellipse(centerX: 150, y: 80, radius: 40))
     ctx.draw(polygon: Polygon(points: [
-        Vec2(x: 210.0, y: 150.0),
-        Vec2(x: 100.0, y: 200.0),
-        Vec2(x: 170.0, y: 250.0)
-    ], isFilled: false))
+        Vec2(x: 250.0, y: 120.0),
+        Vec2(x: 280.0, y: 250.0),
+        Vec2(x: 200.0, y: 170.0),
+        Vec2(x: 300.0, y: 170.0),
+        Vec2(x: 220.0, y: 250.0)
+    ], isFilled: true))
+    ctx.draw(polygon: Polygon(paths: [
+        [
+            Vec2(x: 20.0, y: 150.0),
+            Vec2(x: 120.0, y: 150.0),
+            Vec2(x: 120.0, y: 250.0),
+            Vec2(x: 20.0, y: 250.0)
+        ],
+        [
+            Vec2(x: 70.0, y: 170.0),
+            Vec2(x: 10.0, y: 220.0),
+            Vec2(x: 130.0, y: 220.0),
+        ]
+    ], isFilled: true))
 
     // Encode the image to a byte buffer
     let image = try ctx.makeImage()

--- a/Snippets/DrawShapes.swift
+++ b/Snippets/DrawShapes.swift
@@ -11,6 +11,11 @@ func generatePngImage() throws -> Data {
     ctx.draw(rect: Rectangle(fromX: 80, y: 90, width: 10, height: 40, color: .yellow))
     ctx.draw(text: Text("Test", at: Vec2(x: 0, y: 15)))
     ctx.draw(ellipse: Ellipse(centerX: 150, y: 80, radius: 40))
+    ctx.draw(polygon: Polygon(points: [
+        Vec2(x: 210.0, y: 150.0),
+        Vec2(x: 100.0, y: 200.0),
+        Vec2(x: 170.0, y: 250.0)
+    ], isFilled: false))
 
     // Encode the image to a byte buffer
     let image = try ctx.makeImage()

--- a/Sources/CairoGraphics/context/CairoContext.swift
+++ b/Sources/CairoGraphics/context/CairoContext.swift
@@ -100,6 +100,26 @@ public final class CairoContext: GraphicsContext {
         }
     }
 
+    public func draw(polygon: Polygon<Double>) {
+        guard polygon.points.count > 0 else {
+            return
+        }
+
+        markImageAsUnflushed()
+        context.setSource(color: polygon.color.asDoubleTuple)
+
+        context.move(to: polygon.points.first!.asTuple)
+        for point in polygon.points.suffix(polygon.points.count - 1) {
+            context.line(to: point.asTuple)
+        }
+
+        if polygon.isFilled {
+            context.fill()
+        } else {
+            context.stroke()
+        }
+    }
+
     public func draw(image: CairoImage, at position: Vec2<Double>, withSize size: Vec2<Int>, rotation optionalRotation: Double?) {
         draw(surface: image.surface, of: image.size, at: position, withSize: size, rotation: optionalRotation)
     }

--- a/Sources/CairoGraphics/context/CairoContext.swift
+++ b/Sources/CairoGraphics/context/CairoContext.swift
@@ -101,16 +101,18 @@ public final class CairoContext: GraphicsContext {
     }
 
     public func draw(polygon: Polygon<Double>) {
-        guard polygon.points.count > 0 else {
+        guard polygon.paths.count > 0 else {
             return
         }
 
         markImageAsUnflushed()
         context.setSource(color: polygon.color.asDoubleTuple)
 
-        context.move(to: polygon.points.first!.asTuple)
-        for point in polygon.points.suffix(polygon.points.count - 1) {
-            context.line(to: point.asTuple)
+        for path in polygon.paths {
+            context.move(to: path.first!.asTuple)
+            for point in path.suffix(path.count - 1) {
+                context.line(to: point.asTuple)
+            }
         }
 
         if polygon.isFilled {

--- a/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
+++ b/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
@@ -126,6 +126,15 @@ public final class CoreGraphicsContext: GraphicsContext {
         }
     }
 
+    public func draw(polygon: Graphics.Polygon<Double>) {
+        guard polygon.points.count > 0 else {
+            return
+        }
+        withPath(color: polygon.color, isFilled: polygon.isFilled) {
+            cgContext.addLines(between: polygon.points.map { cgPoint(for: $0) })
+        }
+    }
+
     public func draw(ellipse: Ellipse<Double>) {
         withPath(color: ellipse.color, isFilled: ellipse.isFilled) {
             cgContext.addEllipse(in: cgRect(for: ellipse.boundingRectangle))

--- a/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
+++ b/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
@@ -127,11 +127,13 @@ public final class CoreGraphicsContext: GraphicsContext {
     }
 
     public func draw(polygon: Graphics.Polygon<Double>) {
-        guard polygon.points.count > 0 else {
+        guard polygon.paths.count > 0 else {
             return
         }
         withPath(color: polygon.color, isFilled: polygon.isFilled) {
-            cgContext.addLines(between: polygon.points.map { cgPoint(for: $0) })
+            for path in polygon.paths {
+                cgContext.addLines(between: path.map { cgPoint(for: $0) })
+            }
         }
     }
 

--- a/Sources/Graphics/context/GraphicsContext.swift
+++ b/Sources/Graphics/context/GraphicsContext.swift
@@ -43,6 +43,9 @@ public protocol GraphicsContext {
 
     /** Draws the given text to this context. */
     func draw(text: Text)
+
+    /** Draws the given polygon in this context. */
+    func draw(polygon: Polygon<Double>)
 }
 
 public extension GraphicsContext {

--- a/Sources/Graphics/shape/Polygon.swift
+++ b/Sources/Graphics/shape/Polygon.swift
@@ -13,7 +13,7 @@ public struct Polygon<T: IntExpressibleAlgebraicField> {
         self.color = color
         self.isFilled = isFilled
 
-        if isFilled && points.count > 1 && points.first! != points.last! {
+        if points.count > 1 && points.first! != points.last! {
             var closedPoints = points
             closedPoints.append(points.first!)
             self.points = closedPoints

--- a/Sources/Graphics/shape/Polygon.swift
+++ b/Sources/Graphics/shape/Polygon.swift
@@ -1,0 +1,17 @@
+import Utils
+
+public struct Polygon<T: IntExpressibleAlgebraicField> {
+    public let points: [Vec2<T>]
+    public let color: Color
+    public let isFilled: Bool
+
+    public init(
+        points: [Vec2<T>],
+        color: Color = ShapeDefaults.color,
+        isFilled: Bool = ShapeDefaults.isFilled
+    ) {
+        self.points = points
+        self.color = color
+        self.isFilled = isFilled
+    }
+}

--- a/Sources/Graphics/shape/Polygon.swift
+++ b/Sources/Graphics/shape/Polygon.swift
@@ -1,24 +1,36 @@
 import Utils
 
 public struct Polygon<T: IntExpressibleAlgebraicField> {
-    public let points: [Vec2<T>]
+    public let paths: [[Vec2<T>]]
     public let color: Color
     public let isFilled: Bool
 
     public init(
-        points: [Vec2<T>],
+        paths: [[Vec2<T>]],
         color: Color = ShapeDefaults.color,
         isFilled: Bool = ShapeDefaults.isFilled
     ) {
         self.color = color
         self.isFilled = isFilled
 
-        if points.count > 1 && points.first! != points.last! {
-            var closedPoints = points
-            closedPoints.append(points.first!)
-            self.points = closedPoints
-        } else {
-            self.points = points
+        self.paths = paths.compactMap {
+            if $0.count > 1 && $0.first! != $0.last {
+                var closedPaths = $0
+                closedPaths.append($0.first!)
+                return closedPaths
+            } else if $0.count > 1 {
+                return $0
+            } else {
+                return nil
+            }
         }
+    }
+
+    public init(
+        points: [Vec2<T>],
+        color: Color = ShapeDefaults.color,
+        isFilled: Bool = ShapeDefaults.isFilled
+    ) {
+        self.init(paths: [points], color: color, isFilled: isFilled)
     }
 }

--- a/Sources/Graphics/shape/Polygon.swift
+++ b/Sources/Graphics/shape/Polygon.swift
@@ -10,8 +10,15 @@ public struct Polygon<T: IntExpressibleAlgebraicField> {
         color: Color = ShapeDefaults.color,
         isFilled: Bool = ShapeDefaults.isFilled
     ) {
-        self.points = points
         self.color = color
         self.isFilled = isFilled
+
+        if isFilled && points.count > 1 && points.first! != points.last! {
+            var closedPoints = points
+            closedPoints.append(points.first!)
+            self.points = closedPoints
+        } else {
+            self.points = points
+        }
     }
 }

--- a/Tests/GraphicsTests/ShapeTests.swift
+++ b/Tests/GraphicsTests/ShapeTests.swift
@@ -11,23 +11,56 @@ final class ShapeTests: XCTestCase {
         ("testFilledPolygonAlreadyClosed", testFilledPolygonAlreadyClosed),
     ]
 
+    func testEmptyPointsList() {
+        let polygon = Polygon(points: [Vec2<Double>]())
+        XCTAssertEqual(polygon.paths.count, 0)
+    }
+
+    func testEmptyPathsList() {
+        let polygon = Polygon(paths: [[Vec2<Double>]]())
+        XCTAssertEqual(polygon.paths.count, 0)
+    }
+
     func testStrokedPolygon() {
         let points = [Vec2(x: 1, y: 2), Vec2(x: 2, y: 2), Vec2(x: 1, y: 1)]
         let polygon = Polygon(points: points, isFilled: false)
-        XCTAssertEqual(points.count + 1, polygon.points.count, "Polygon should have extra points")
-        XCTAssertEqual(polygon.points.first!, polygon.points.last!, "Polygon should be closed.")
+
+        XCTAssertEqual(polygon.paths.count, 1, "Should be one path in polygon")
+        let path = polygon.paths.first!
+
+        XCTAssertEqual(points.count + 1, path.count, "Polygon should have extra points")
+        XCTAssertEqual(path.first!, path.last!, "Polygon should be closed.")
     }
 
     func testFilledPolygon() {
         let points = [Vec2(x: 1, y: 2), Vec2(x: 2, y: 2), Vec2(x: 1, y: 1)]
         let polygon = Polygon(points: points, isFilled: true)
-        XCTAssertEqual(points.count + 1, polygon.points.count, "Polygon should have extra points")
-        XCTAssertEqual(polygon.points.first!, polygon.points.last!, "Polygon should be closed.")
+
+        XCTAssertEqual(polygon.paths.count, 1, "Should be one path in polygon")
+        let path = polygon.paths.first!
+
+        XCTAssertEqual(points.count + 1, path.count, "Polygon should have extra points")
+        XCTAssertEqual(path.first!, path.last!, "Polygon should be closed.")
     }
 
     func testFilledPolygonAlreadyClosed() {
         let points = [Vec2(x: 1, y: 2), Vec2(x: 2, y: 2), Vec2(x: 1, y: 1), Vec2(x: 1, y:2)]
-        let polygon = Polygon(points: points, isFilled: true)
-        XCTAssertEqual(points, polygon.points, "Polygon should not have extra points")
+        let polygon = Polygon(points: points)
+
+        XCTAssertEqual(polygon.paths.count, 1, "Should be one path in polygon")
+        let path = polygon.paths.first!
+
+        XCTAssertEqual(points, path, "Polygon should not have extra points")
+    }
+
+    func testMultiPathPolygon() {
+        let closedpoints = [Vec2(x: 10, y: 20), Vec2(x: 20, y: 20), Vec2(x: 10, y: 10), Vec2(x: 10, y:20)]
+        let openpoints = [Vec2(x: 1, y: 2), Vec2(x: 2, y: 2), Vec2(x: 1, y: 1)]
+        let polygon = Polygon(paths: [closedpoints, openpoints])
+
+        XCTAssertEqual(polygon.paths.count, 2, "Should be one path in polygon")
+
+        XCTAssertEqual(polygon.paths.first!.count, closedpoints.count, "Closed path shouldn't have more points")
+        XCTAssertEqual(polygon.paths.last!.count, openpoints.count + 1, "Open path should have an additional point")
     }
 }

--- a/Tests/GraphicsTests/ShapeTests.swift
+++ b/Tests/GraphicsTests/ShapeTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+import Utils
+
+@testable import Graphics
+
+final class ShapeTests: XCTestCase {
+    static var allTests = [
+        ("testStrokedPolygon", testStrokedPolygon),
+        ("testFilledPolygon", testFilledPolygon),
+        ("testFilledPolygonAlreadyClosed", testFilledPolygonAlreadyClosed),
+    ]
+
+    func testStrokedPolygon() {
+        let points = [Vec2(x: 1, y: 2), Vec2(x: 2, y: 2), Vec2(x: 1, y: 1)]
+        let polygon = Polygon(points: points, isFilled: false)
+        XCTAssertEqual(points, polygon.points, "Polygon should not have modified points")
+    }
+
+    func testFilledPolygon() {
+        let points = [Vec2(x: 1, y: 2), Vec2(x: 2, y: 2), Vec2(x: 1, y: 1)]
+        let polygon = Polygon(points: points, isFilled: true)
+        XCTAssertEqual(points.count + 1, polygon.points.count, "Polygon should have extra points")
+        XCTAssertEqual(polygon.points.first!, polygon.points.last!, "Polygon should be closed.")
+    }
+
+    func testFilledPolygonAlreadyClosed() {
+        let points = [Vec2(x: 1, y: 2), Vec2(x: 2, y: 2), Vec2(x: 1, y: 1), Vec2(x: 1, y:2)]
+        let polygon = Polygon(points: points, isFilled: true)
+        XCTAssertEqual(points, polygon.points, "Polygon should not have extra points")
+    }
+}

--- a/Tests/GraphicsTests/ShapeTests.swift
+++ b/Tests/GraphicsTests/ShapeTests.swift
@@ -14,7 +14,8 @@ final class ShapeTests: XCTestCase {
     func testStrokedPolygon() {
         let points = [Vec2(x: 1, y: 2), Vec2(x: 2, y: 2), Vec2(x: 1, y: 1)]
         let polygon = Polygon(points: points, isFilled: false)
-        XCTAssertEqual(points, polygon.points, "Polygon should not have modified points")
+        XCTAssertEqual(points.count + 1, polygon.points.count, "Polygon should have extra points")
+        XCTAssertEqual(polygon.points.first!, polygon.points.last!, "Polygon should be closed.")
     }
 
     func testFilledPolygon() {

--- a/Tests/GraphicsTests/XCTestManifests.swift
+++ b/Tests/GraphicsTests/XCTestManifests.swift
@@ -3,7 +3,8 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
 	return [
-		testCase(ColorTests.allTests)
+		testCase(ColorTests.allTests),
+		testCase(ShapeTests.allTests)
 	]
 }
 #endif


### PR DESCRIPTION
I was looking to use this for a specific application that needs polygon support, so I've added a basic Polygon shape type. 

I manually tested this under both macOS 13 and Fedora 37, and the example in the snippet works (tested both filled and unfilled).