### PR TITLE
Support grayscale 8bpp images too

### DIFF
--- a/Sources/CairoGraphics/context/CairoContext.swift
+++ b/Sources/CairoGraphics/context/CairoContext.swift
@@ -19,7 +19,11 @@ public final class CairoContext: GraphicsContext {
     }
 
     public convenience init(width: Int, height: Int) throws {
-        self.init(image: try CairoImage(width: width, height: height))
+        try self.init(width: width, height: height, format: .rgba32)
+    }
+
+    public convenience init(width: Int, height: Int, format: PixelFormat) throws {
+        self.init(image: try CairoImage(width: width, height: height, format: format))
     }
 
     public func makeImage() throws -> CairoImage {

--- a/Sources/CairoGraphics/context/CairoContext.swift
+++ b/Sources/CairoGraphics/context/CairoContext.swift
@@ -18,10 +18,6 @@ public final class CairoContext: GraphicsContext {
         self.image = image
     }
 
-    public convenience init(width: Int, height: Int) throws {
-        try self.init(width: width, height: height, format: .rgba32)
-    }
-
     public convenience init(width: Int, height: Int, format: PixelFormat) throws {
         self.init(image: try CairoImage(width: width, height: height, format: format))
     }

--- a/Sources/CairoGraphics/image/CairoImage.swift
+++ b/Sources/CairoGraphics/image/CairoImage.swift
@@ -6,6 +6,18 @@ import Utils
 
 fileprivate let log = Logger(label: "CairoGraphics.CairoImage")
 
+private extension PixelFormat {
+
+    var imageFormat: ImageFormat {
+        switch self {
+            case .rgba32:
+                return .argb32
+            case .g8:
+                return .a8
+        }
+    }
+}
+
 /**
  * An image that internally wraps a Cairo surface.
  */
@@ -56,12 +68,20 @@ public final class CairoImage: BufferedImage {
     }
 
     public convenience init(width: Int, height: Int) throws {
-        let surface = try Surface.Image(format: .argb32, width: width, height: height)
-        self.init(rawSurface: surface)
+        try self.init(width: width, height: height, format: .rgba32)
     }
 
     public convenience init(size: Vec2<Int>) throws {
-        try self.init(width: size.x, height: size.y)
+        try self.init(size: size, format: .rgba32)
+    }
+
+    public convenience init(width: Int, height: Int, format: PixelFormat) throws {
+        let surface = try Surface.Image(format: format.imageFormat, width: width, height: height)
+        self.init(rawSurface: surface)
+    }
+
+    public convenience init(size: Vec2<Int>, format: PixelFormat) throws {
+        try self.init(width: size.x, height: size.y, format: format)
     }
 
     public subscript(_ y: Int, _ x: Int) -> Color {

--- a/Sources/CairoGraphics/image/CairoImage.swift
+++ b/Sources/CairoGraphics/image/CairoImage.swift
@@ -67,21 +67,10 @@ public final class CairoImage: BufferedImage {
         return try surface.writePNG()
     }
 
-    public convenience init(width: Int, height: Int) throws {
-        try self.init(width: width, height: height, format: .rgba32)
-    }
-
-    public convenience init(size: Vec2<Int>) throws {
-        try self.init(size: size, format: .rgba32)
-    }
 
     public convenience init(width: Int, height: Int, format: PixelFormat) throws {
         let surface = try Surface.Image(format: format.imageFormat, width: width, height: height)
         self.init(rawSurface: surface)
-    }
-
-    public convenience init(size: Vec2<Int>, format: PixelFormat) throws {
-        try self.init(width: size.x, height: size.y, format: format)
     }
 
     public subscript(_ y: Int, _ x: Int) -> Color {

--- a/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
+++ b/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
@@ -23,7 +23,7 @@ private extension PixelFormat {
         }
     }
 
-    var bitsPerPixel: Int {
+    var bytesPerPixel: Int {
         switch self {
             case .rgba32:
                 return 4
@@ -61,13 +61,13 @@ public final class CoreGraphicsContext: GraphicsContext {
     }
 
     public init(width: Int, height: Int, format: PixelFormat) throws {
-        let dataPointer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: width * height * format.bitsPerPixel)
+        let dataPointer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: width * height * format.bytesPerPixel)
         guard let cgContext = CGContext(
             data: dataPointer.baseAddress,
             width: width,
             height: height,
             bitsPerComponent: 8,
-            bytesPerRow: width * format.bitsPerPixel,
+            bytesPerRow: width * format.bytesPerPixel,
             space: format.colorSpace,
             bitmapInfo: format.bitmapInfo,
             releaseCallback: nil,
@@ -78,10 +78,6 @@ public final class CoreGraphicsContext: GraphicsContext {
 
         self.dataPointer = dataPointer
         self.cgContext = cgContext
-    }
-
-    public convenience init (width: Int, height: Int) throws {
-        try self.init(width: width, height: height, format: .rgba32)
     }
 
     public func makeImage() throws -> CoreGraphicsImage {

--- a/Sources/Graphics/context/GraphicsContext.swift
+++ b/Sources/Graphics/context/GraphicsContext.swift
@@ -1,17 +1,9 @@
 import Utils
 
-public enum PixelFormat {
-    case rgba32
-    case g8
-}
-
 /** A stateful 2D drawing environment. */
 public protocol GraphicsContext {
     associatedtype Image: Sized
     associatedtype SVG: Sized
-
-    /** Creates a new context with the given width and height in RGBA32. */
-    init(width: Int, height: Int) throws
 
     /** Creates a new context with the given width and height and format. */
     init(width: Int, height: Int, format: PixelFormat) throws
@@ -54,6 +46,12 @@ public protocol GraphicsContext {
 
     /** Draws the given polygon in this context. */
     func draw(polygon: Polygon<Double>)
+}
+
+public extension GraphicsContext {
+    init (width: Int, height: Int) throws {
+        try self.init(width: width, height: height, format: .rgba32)
+    }
 }
 
 public extension GraphicsContext {

--- a/Sources/Graphics/context/GraphicsContext.swift
+++ b/Sources/Graphics/context/GraphicsContext.swift
@@ -1,12 +1,20 @@
 import Utils
 
+public enum PixelFormat {
+    case rgba32
+    case g8
+}
+
 /** A stateful 2D drawing environment. */
 public protocol GraphicsContext {
     associatedtype Image: Sized
     associatedtype SVG: Sized
 
-    /** Creates a new context with the given width and height. */
+    /** Creates a new context with the given width and height in RGBA32. */
     init(width: Int, height: Int) throws
+
+    /** Creates a new context with the given width and height and format. */
+    init(width: Int, height: Int, format: PixelFormat) throws
 
     /** Creates an image from this context. */
     func makeImage() throws -> Image

--- a/Sources/Graphics/context/PixelFormat.swift
+++ b/Sources/Graphics/context/PixelFormat.swift
@@ -1,0 +1,8 @@
+/** Supported backend pixel formats **/
+public enum PixelFormat {
+    /** Full color with alpha in 4 bytes per pixel **/
+    case rgba32
+
+    /** Grayscale in 1 byte per pixel **/
+    case g8
+}

--- a/Sources/Graphics/image/BufferedImage.swift
+++ b/Sources/Graphics/image/BufferedImage.swift
@@ -1,3 +1,5 @@
+import Utils
+
 /**
  * A mutable image that provides direct access to its pixels.
  */
@@ -5,4 +7,19 @@ public protocol BufferedImage: Image {
     init(width: Int, height: Int, format: PixelFormat) throws
 
     subscript(_ y: Int, _ x: Int) -> Color { get set }
+}
+
+public extension BufferedImage {
+    init(width: Int, height: Int) throws {
+        try self.init(width: width, height: height, format: .rgba32)
+    }
+
+
+    init(size: Vec2<Int>) throws {
+        try self.init(size: size, format: .rgba32)
+    }
+
+    init(size: Vec2<Int>, format: PixelFormat) throws {
+        try self.init(width: size.x, height: size.y, format: format)
+    }
 }

--- a/Sources/Graphics/image/BufferedImage.swift
+++ b/Sources/Graphics/image/BufferedImage.swift
@@ -2,7 +2,7 @@
  * A mutable image that provides direct access to its pixels.
  */
 public protocol BufferedImage: Image {
-    init(width: Int, height: Int) throws
+    init(width: Int, height: Int, format: PixelFormat) throws
 
     subscript(_ y: Int, _ x: Int) -> Color { get set }
 }


### PR DESCRIPTION
This PR adds a PixelFormat enum that can optionally be passed to the context constructor, which lets you have both 32 bpp RGBA (the current default and only option) along side a greyscale 8 bpp option.

To avoid upsetting existing API users, convenience constructors exist that will just use the current RGBA default, so existing code should just work as is.

I manually tested this under both Cairo and CoreGraphics on macOS.

Obviously other formats could be added, just I need greyscale 8bpp for my current project, which is why I limited it to an option I was actively using.