### PR TITLE
Allow raw data access

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,7 +58,7 @@ let package = Package(
         .testTarget(
             name: "GraphicsTests",
             dependencies: [
-                .target(name: "Graphics"),
+                .target(name: "PlatformGraphics"),
             ]
         )
     ]

--- a/Sources/CairoGraphics/context/CairoContext.swift
+++ b/Sources/CairoGraphics/context/CairoContext.swift
@@ -184,4 +184,11 @@ public final class CairoContext: GraphicsContext {
 
         context.restore()
     }
+
+    public func withUnsafeMutableBytes(_ body: (UnsafeMutableBufferPointer<UInt8>) throws -> Void) throws {
+        try image.surface.withUnsafeMutableBytes {
+            let dataPointer = UnsafeMutableBufferPointer(start: $0, count: image.surface.stride * image.surface.height)
+            try body(dataPointer)
+        }
+    }
 }

--- a/Sources/CairoGraphics/context/CairoContext.swift
+++ b/Sources/CairoGraphics/context/CairoContext.swift
@@ -185,10 +185,10 @@ public final class CairoContext: GraphicsContext {
         context.restore()
     }
 
-    public func withUnsafeMutableBytes(_ body: (UnsafeMutableBufferPointer<UInt8>) throws -> Void) throws {
+    public func withUnsafeMutableBytes(_ body: (UnsafeMutableBufferPointer<UInt8>, Int) throws -> Void) throws {
         try image.surface.withUnsafeMutableBytes {
             let dataPointer = UnsafeMutableBufferPointer(start: $0, count: image.surface.stride * image.surface.height)
-            try body(dataPointer)
+            try body(dataPointer, image.surface.stride)
         }
     }
 }

--- a/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
+++ b/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
@@ -194,11 +194,11 @@ public final class CoreGraphicsContext: GraphicsContext {
         CTLineDraw(line, cgContext)
     }
 
-    public func withUnsafeMutableBytes(_ body: (UnsafeMutableBufferPointer<UInt8>) throws -> Void) throws {
+    public func withUnsafeMutableBytes(_ body: (UnsafeMutableBufferPointer<UInt8>, Int) throws -> Void) throws {
         guard let dataPointer = dataPointer else {
             throw GraphicsContextError.noRawBuffer
         }
-        try body(dataPointer)
+        try body(dataPointer, width * format.bytesPerPixel)
     }
 }
 

--- a/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
+++ b/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
@@ -192,6 +192,13 @@ public final class CoreGraphicsContext: GraphicsContext {
         cgContext.textPosition = CGPoint(x: bounds.minX + offset.x, y: bounds.minY + offset.y)
         CTLineDraw(line, cgContext)
     }
+
+    public func withUnsafeMutableBytes(_ body: (UnsafeMutableBufferPointer<UInt8>) throws -> Void) throws {
+        guard let dataPointer = dataPointer else {
+            throw GraphicsContextError.noRawBuffer
+        }
+        try body(dataPointer)
+    }
 }
 
 extension Color {

--- a/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
+++ b/Sources/CoreGraphicsGraphics/context/CoreGraphicsContext.swift
@@ -62,6 +62,7 @@ public final class CoreGraphicsContext: GraphicsContext {
 
     public init(width: Int, height: Int, format: PixelFormat) throws {
         let dataPointer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: width * height * format.bytesPerPixel)
+        dataPointer.initialize(repeating: 0)
         guard let cgContext = CGContext(
             data: dataPointer.baseAddress,
             width: width,

--- a/Sources/Graphics/context/GraphicsContext.swift
+++ b/Sources/Graphics/context/GraphicsContext.swift
@@ -46,6 +46,9 @@ public protocol GraphicsContext {
 
     /** Draws the given polygon in this context. */
     func draw(polygon: Polygon<Double>)
+
+    /** Allow access to raw bytes. */
+    func withUnsafeMutableBytes(_ body: (UnsafeMutableBufferPointer<UInt8>) throws -> Void) throws
 }
 
 public extension GraphicsContext {

--- a/Sources/Graphics/context/GraphicsContext.swift
+++ b/Sources/Graphics/context/GraphicsContext.swift
@@ -48,7 +48,7 @@ public protocol GraphicsContext {
     func draw(polygon: Polygon<Double>)
 
     /** Allow access to raw bytes. */
-    func withUnsafeMutableBytes(_ body: (UnsafeMutableBufferPointer<UInt8>) throws -> Void) throws
+    func withUnsafeMutableBytes(_ body: (UnsafeMutableBufferPointer<UInt8>, Int) throws -> Void) throws
 }
 
 public extension GraphicsContext {

--- a/Sources/Graphics/context/GraphicsContextError.swift
+++ b/Sources/Graphics/context/GraphicsContextError.swift
@@ -1,4 +1,5 @@
 public enum GraphicsContextError: Error {
     case couldNotCreate(width: Int, height: Int)
     case couldNotMakeImage
+    case noRawBuffer
 }

--- a/Tests/GraphicsTests/ContextTests.swift
+++ b/Tests/GraphicsTests/ContextTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+@testable import PlatformGraphics
+
+final class ContextTests: XCTestCase {
+    func testSimpleDrawRect() throws {
+        let ctx = try PlatformGraphicsContext(width: 8, height: 8, format: .g8)
+        ctx.draw(rect: Rectangle(fromX: 0, y: 4, width: 8, height: 4, color: .white, isFilled: true))
+        try ctx.withUnsafeMutableBytes { buffer in
+            // first half should be black, second half should be white
+            for idx in 0..<32 {
+                XCTAssertEqual(buffer[idx], 0, "Expected black pixel")
+            }
+            for idx in 32..<64 {
+                XCTAssertEqual(buffer[idx], 255, "Expected white pixel")
+            }
+        }
+    }
+}

--- a/Tests/GraphicsTests/ContextTests.swift
+++ b/Tests/GraphicsTests/ContextTests.swift
@@ -16,4 +16,25 @@ final class ContextTests: XCTestCase {
             }
         }
     }
+
+    func testMemoryIsInitialized() throws {
+        // This test is a bit statistical, which I don't like, but I'm not sure how better
+        // to implement this. There was a bug whereby the data for CoreGraphics was not
+        // being initialized, which usually was fine the first time you created a context
+        // but at some point would start to contain old data as the memory allocator re-used
+        // previously released memory. Because we can't force the bug, this test just repeats
+        // it enough that FOR ME we hit the issue, and so I could be convinced my fix worked,
+        // but I'm open to better implementations here.
+        for _ in 0..<10 {
+            let ctx = try PlatformGraphicsContext(width: 100, height: 100, format: .g8)
+            try ctx.withUnsafeMutableBytes { buffer in
+                // a new buffer should be all black
+                for idx in 0..<10000 {
+                    XCTAssertEqual(buffer[idx], 0, "Expected black pixel")
+                }
+            }
+            // fill with white - eventually we'll be re-allocated this memory
+            ctx.draw(rect: Rectangle(fromX: 0, y: 0, width: 100, height: 100, color: .white, isFilled: true))
+        }
+    }
 }


### PR DESCRIPTION
The last of my changes for now :) I'm using this library in the context of generating GeoTIFFs for geospatial analysis, so rather than saving PNGs, I want to get the raw bytes and write them out to another file format. This also has other uses, including making test writing easier.

Whilst working on my project, where the geospatial TIFFs are processed in chunks due to size (400000x200000!), I was rasterising vector maps in chunks, and noticed that I was getting old data in new chunks, because the CoreGraphics buffer wasn't initialised after allocation.